### PR TITLE
Integrated httpcapture (taking Pebble screenshots)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+build
+xcuserdata
+*.xcworkspace

--- a/httpebble.xcodeproj/project.pbxproj
+++ b/httpebble.xcodeproj/project.pbxproj
@@ -48,8 +48,8 @@
 		89A25B67174DB490008BED04 /* NSData+Base64.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSData+Base64.h"; sourceTree = "<group>"; };
 		89A25B68174DB490008BED04 /* NSData+Base64.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSData+Base64.m"; sourceTree = "<group>"; };
 		89AC134017458F0F006847A7 /* PebbleModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = PebbleModel.xcdatamodel; sourceTree = "<group>"; };
-		89AC134517459B20006847A7 /* KBPebbleValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = KBPebbleValue.h; path = httpebble/KBPebbleValue.h; sourceTree = "<group>"; };
-		89AC134617459B20006847A7 /* KBPebbleValue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = KBPebbleValue.m; path = httpebble/KBPebbleValue.m; sourceTree = "<group>"; };
+		89AC134517459B20006847A7 /* KBPebbleValue.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = KBPebbleValue.h; sourceTree = "<group>"; };
+		89AC134617459B20006847A7 /* KBPebbleValue.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = KBPebbleValue.m; sourceTree = "<group>"; };
 		89AC13821745B12D006847A7 /* CoreData.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreData.framework; path = System/Library/Frameworks/CoreData.framework; sourceTree = SDKROOT; };
 		89AC1384174632E4006847A7 /* CoreLocation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreLocation.framework; path = System/Library/Frameworks/CoreLocation.framework; sourceTree = SDKROOT; };
 		89AC13861746F465006847A7 /* cloudpebble.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = cloudpebble.png; sourceTree = "<group>"; };
@@ -108,16 +108,6 @@
 		89E96D1D173DA96B00E2DE9D = {
 			isa = PBXGroup;
 			children = (
-				89AC1384174632E4006847A7 /* CoreLocation.framework */,
-				89AC13821745B12D006847A7 /* CoreData.framework */,
-				89AC133F17458F0F006847A7 /* PebbleModel.xcdatamodeld */,
-				89AC134517459B20006847A7 /* KBPebbleValue.h */,
-				89AC134617459B20006847A7 /* KBPebbleValue.m */,
-				89E96D5B173DB49500E2DE9D /* MessageUI.framework */,
-				89E96D59173DB47D00E2DE9D /* CoreMotion.framework */,
-				89E96D57173DB47600E2DE9D /* ExternalAccessory.framework */,
-				89E96D55173DB46D00E2DE9D /* CoreBluetooth.framework */,
-				89E96D53173DB46600E2DE9D /* libz.dylib */,
 				89E96D2F173DA96B00E2DE9D /* httpebble */,
 				89E96D28173DA96B00E2DE9D /* Frameworks */,
 				89E96D27173DA96B00E2DE9D /* Products */,
@@ -135,6 +125,13 @@
 		89E96D28173DA96B00E2DE9D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				89E96D5B173DB49500E2DE9D /* MessageUI.framework */,
+				89E96D59173DB47D00E2DE9D /* CoreMotion.framework */,
+				89E96D57173DB47600E2DE9D /* ExternalAccessory.framework */,
+				89E96D55173DB46D00E2DE9D /* CoreBluetooth.framework */,
+				89E96D53173DB46600E2DE9D /* libz.dylib */,
+				89AC1384174632E4006847A7 /* CoreLocation.framework */,
+				89AC13821745B12D006847A7 /* CoreData.framework */,
 				89E96D4E173DAAA200E2DE9D /* PebbleVendor.framework */,
 				89E96D4C173DAA9800E2DE9D /* PebbleKit.framework */,
 				89E96D29173DA96B00E2DE9D /* UIKit.framework */,
@@ -147,6 +144,9 @@
 		89E96D2F173DA96B00E2DE9D /* httpebble */ = {
 			isa = PBXGroup;
 			children = (
+				89AC133F17458F0F006847A7 /* PebbleModel.xcdatamodeld */,
+				89AC134517459B20006847A7 /* KBPebbleValue.h */,
+				89AC134617459B20006847A7 /* KBPebbleValue.m */,
 				89E96D38173DA96B00E2DE9D /* KBAppDelegate.h */,
 				89E96D39173DA96B00E2DE9D /* KBAppDelegate.m */,
 				89E96D41173DA96B00E2DE9D /* KBViewController.h */,
@@ -408,7 +408,8 @@
 				89AC134017458F0F006847A7 /* PebbleModel.xcdatamodel */,
 			);
 			currentVersion = 89AC134017458F0F006847A7 /* PebbleModel.xcdatamodel */;
-			path = PebbleModel.xcdatamodeld;
+			name = PebbleModel.xcdatamodeld;
+			path = ../PebbleModel.xcdatamodeld;
 			sourceTree = "<group>";
 			versionGroupType = wrapper.xcdatamodel;
 		};

--- a/httpebble/KBPebbleThing.h
+++ b/httpebble/KBPebbleThing.h
@@ -29,5 +29,6 @@
 - (void)saveKeyValueData;
 - (void)disconnect;
 - (void)connect;
+- (void)requestScreenshot;
 
 @end

--- a/httpebble/KBPebbleThing.h
+++ b/httpebble/KBPebbleThing.h
@@ -9,15 +9,15 @@
 #import <Foundation/Foundation.h>
 
 @class PBWatch;
-
-
 @class KBPebbleThing;
+
 @protocol KBPebbleThingDelegate <NSObject>
 
 - (void)pebbleThing:(KBPebbleThing*)thing connected:(PBWatch *)watch;
 - (void)pebbleThing:(KBPebbleThing*)thing disconnected:(PBWatch *)watch;
 - (void)pebbleThing:(KBPebbleThing*)thing found:(PBWatch*)watch;
 - (void)pebbleThing:(KBPebbleThing*)thing lost:(PBWatch *)watch;
+- (void)pebbleThing:(KBPebbleThing*)thing frameBuffer:(NSData *)buffer fromIndex:(NSInteger)index;
 
 @end
 

--- a/httpebble/KBPebbleThing.m
+++ b/httpebble/KBPebbleThing.m
@@ -166,6 +166,10 @@
     [self setOurWatch:nil];
 }
 
+- (void)requestScreenshot {
+    [ourWatch appMessagesPushUpdate:@{HTTP_FRAMEBUFFER_SLICE: @(0)} onSent:nil];
+}
+
 #pragma mark CLLocationManager delegate
 
 NSNumber* floatAsPBNumber(float value) {

--- a/httpebble/KBViewController.h
+++ b/httpebble/KBViewController.h
@@ -9,21 +9,19 @@
 #import <UIKit/UIKit.h>
 #import "KBPebbleThing.h"
 
-@interface KBViewController: UIViewController<KBPebbleThingDelegate>  {
+@interface KBViewController: UIViewController<KBPebbleThingDelegate, UIAlertViewDelegate>  {
     IBOutlet UILabel* connectedLabel;
     IBOutlet UIButton* connectButton;
     BOOL shouldBeConnected;
     BOOL couldConnect;
     BOOL isConnected;
+    IBOutlet UIImageView* screenImageView;
+    unsigned char frameBuffer[144*168*4];
 }
 
-- (void)pebbleThing:(KBPebbleThing*)thing connected:(PBWatch *)watch;
-- (void)pebbleThing:(KBPebbleThing*)thing disconnected:(PBWatch *)watch;
-- (void)pebbleThing:(KBPebbleThing*)thing found:(PBWatch*)watch;
-- (void)pebbleThing:(KBPebbleThing*)thing lost:(PBWatch *)watch;
+@property (nonatomic, retain) KBPebbleThing *pebbleThing;
 
 - (IBAction)toggleConnected:(id)sender;
-
-@property (nonatomic, retain) KBPebbleThing *pebbleThing;
+- (IBAction)saveScreenshot:(id)sender;
 
 @end

--- a/httpebble/KBViewController.m
+++ b/httpebble/KBViewController.m
@@ -18,7 +18,7 @@
 - (void)viewDidLoad
 {
     [super viewDidLoad];
-	// Do any additional setup after loading the view, typically from a nib.
+
     UIImage *buttonImage = [[UIImage imageNamed:@"whiteButton.png"]
                             resizableImageWithCapInsets:UIEdgeInsetsMake(18, 18, 18, 18)];
     UIImage *buttonImageHighlight = [[UIImage imageNamed:@"whiteButtonHighlight.png"]
@@ -29,6 +29,44 @@
     couldConnect = NO;
     [connectButton setHidden:YES];
     [connectedLabel setText:@"No Pebble available."];
+}
+
+#define WIDTH 144
+#define HEIGHT 168
+
+- (UIImage*)frameBufferImage
+{
+    CGColorSpaceRef rgbColorSpace = CGColorSpaceCreateDeviceRGB();
+    
+    CGContextRef bitmap = CGBitmapContextCreate(frameBuffer,
+                                                WIDTH,
+                                                HEIGHT,
+                                                8,
+                                                WIDTH*4,
+                                                rgbColorSpace,
+                                                kCGImageAlphaNoneSkipLast);
+    
+    UIGraphicsBeginImageContext(CGSizeMake(WIDTH, 168));
+    CGImageRef imageRef = CGBitmapContextCreateImage(bitmap);
+    
+    CGContextRef context = UIGraphicsGetCurrentContext();
+    
+    CGContextSetInterpolationQuality(context, kCGInterpolationNone);
+    
+    CGAffineTransform flipVertical = CGAffineTransformMake(1, 0, 0, -1, 0, HEIGHT);
+    CGContextSaveGState(context);
+    CGContextConcatCTM(context, flipVertical);
+    CGContextDrawImage(context, CGRectMake(0, 0, WIDTH, HEIGHT), imageRef);
+    CGContextRestoreGState(context);
+    
+    UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+    UIGraphicsEndImageContext();
+    
+    CGImageRelease(imageRef);
+    CGContextRelease(bitmap);
+    CGColorSpaceRelease(rgbColorSpace);
+    
+    return image;
 }
 
 - (void)pebbleThing:(KBPebbleThing *)thing found:(PBWatch *)watch {
@@ -58,11 +96,62 @@
     [connectedLabel setText:@"No Pebble available."];
 }
 
+- (void)pebbleThing:(KBPebbleThing*)thing frameBuffer:(NSData *)buffer fromIndex:(NSInteger)index {
+    if (!index) {
+        for (int i=0; i<sizeof(frameBuffer); i+=4) {
+            frameBuffer[i+0] = 0x00;
+            frameBuffer[i+1] = 0x00;
+            frameBuffer[i+2] = 0x00;
+            frameBuffer[i+3] = 0xff;
+        }
+    }
+    unsigned char *bytes = (unsigned char *)buffer.bytes;
+    int length = buffer.length;
+    unsigned char *dst = &frameBuffer[index*8*4];
+    if (buffer) {
+        for (int i=0; i<length; i++) {
+            for (int j=0; j<8; j++) {
+                if (bytes[i] & 1<<j) {
+                    *dst++ = 0xff;
+                    *dst++ = 0xff;
+                    *dst++ = 0xff;
+                    *dst++ = 0xff;
+                } else {
+                    *dst++ = 0x00;
+                    *dst++ = 0x00;
+                    *dst++ = 0x00;
+                    *dst++ = 0xff;
+                }
+            }
+        }
+        screenImageView.image = [self frameBufferImage];
+    }
+}
+
 - (void)toggleConnected:(id)sender {
     shouldBeConnected = !shouldBeConnected;
     [[NSUserDefaults standardUserDefaults] setBool:shouldBeConnected forKey:@"ShouldBeConnected"];
     [self handleConnection:_pebbleThing];
     [[NSUserDefaults standardUserDefaults] synchronize];
+}
+
+- (void)image:(UIImage*)image
+didFinishSavingWithError:(NSError*)error
+  contextInfo:(void*)contextInfo
+{
+    [[[UIAlertView alloc] initWithTitle:nil message:@"Saved to the Camera roll." delegate:nil cancelButtonTitle:@"OK" otherButtonTitles:nil] show];
+}
+
+- (void)alertView:(UIAlertView *)alertView clickedButtonAtIndex:(NSInteger)buttonIndex
+{
+    if (buttonIndex == 1)
+        UIImageWriteToSavedPhotosAlbum(screenImageView.image, self, @selector(image:didFinishSavingWithError:contextInfo:), nil);
+    screenImageView.image = nil;
+}
+
+- (IBAction)saveScreenshot:(id)sender {
+    if (screenImageView.image)
+        [[[UIAlertView alloc] initWithTitle:@"Save" message:@"Save screenshot to camera roll?" delegate:self cancelButtonTitle:@"No" otherButtonTitles:@"Yes", nil] show];
 }
 
 - (void)handleConnection:(KBPebbleThing*)thing {
@@ -84,7 +173,6 @@
 - (void)didReceiveMemoryWarning
 {
     [super didReceiveMemoryWarning];
-    // Dispose of any resources that can be recreated.
 }
 
 @end

--- a/httpebble/KBViewController.m
+++ b/httpebble/KBViewController.m
@@ -150,8 +150,11 @@ didFinishSavingWithError:(NSError*)error
 }
 
 - (IBAction)saveScreenshot:(id)sender {
-    if (screenImageView.image)
+    if (screenImageView.image) {
         [[[UIAlertView alloc] initWithTitle:@"Save" message:@"Save screenshot to camera roll?" delegate:self cancelButtonTitle:@"No" otherButtonTitles:@"Yes", nil] show];
+    } else {
+        [self.pebbleThing requestScreenshot];
+    }
 }
 
 - (void)handleConnection:(KBPebbleThing*)thing {

--- a/httpebble/en.lproj/KBViewController.xib
+++ b/httpebble/en.lproj/KBViewController.xib
@@ -2,9 +2,9 @@
 <archive type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="8.00">
 	<data>
 		<int key="IBDocument.SystemTarget">1552</int>
-		<string key="IBDocument.SystemVersion">12D78</string>
+		<string key="IBDocument.SystemVersion">12E55</string>
 		<string key="IBDocument.InterfaceBuilderVersion">3084</string>
-		<string key="IBDocument.AppKitVersion">1187.37</string>
+		<string key="IBDocument.AppKitVersion">1187.39</string>
 		<string key="IBDocument.HIToolboxVersion">626.00</string>
 		<object class="NSMutableDictionary" key="IBDocument.PluginVersions">
 			<string key="NS.key.0">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
@@ -43,7 +43,8 @@
 						<int key="NSvFlags">274</int>
 						<string key="NSFrame">{{60, 57}, {195, 313}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSNextKeyView" ref="345910302"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="662854777"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<int key="IBUIContentMode">2</int>
 						<bool key="IBUIUserInteractionEnabled">NO</bool>
@@ -58,7 +59,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{0, 11}, {320, 38}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSNextKeyView" ref="662730613"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="988349355"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
@@ -92,7 +94,8 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{0, 463}, {320, 21}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
-						<reference key="NSNextKeyView" ref="988349355"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="345910302"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<bool key="IBUIOpaque">NO</bool>
 						<bool key="IBUIClipsSubviews">YES</bool>
@@ -122,6 +125,7 @@
 						<int key="NSvFlags">292</int>
 						<string key="NSFrame">{{93, 497}, {134, 39}}</string>
 						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
 						<string key="NSReuseIdentifierKey">_NS:9</string>
 						<string key="NSHuggingPriority">{750, 250}</string>
 						<bool key="IBUIOpaque">NO</bool>
@@ -132,7 +136,7 @@
 						<string key="IBUINormalTitle">Disconnect</string>
 						<reference key="IBUIHighlightedTitleColor" ref="297749214"/>
 						<reference key="IBUINormalTitleColor" ref="297749214"/>
-						<object class="NSColor" key="IBUINormalTitleShadowColor">
+						<object class="NSColor" key="IBUINormalTitleShadowColor" id="402492274">
 							<int key="NSColorSpace">3</int>
 							<bytes key="NSWhite">MC41AA</bytes>
 						</object>
@@ -146,9 +150,52 @@
 							<int key="NSfFlags">16</int>
 						</object>
 					</object>
+					<object class="IBUIImageView" id="662854777">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{101, 145}, {114, 135}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="875226812"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIUserInteractionEnabled">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+					</object>
+					<object class="IBUIButton" id="875226812">
+						<reference key="NSNextResponder" ref="774585933"/>
+						<int key="NSvFlags">292</int>
+						<string key="NSFrame">{{101, 145}, {114, 135}}</string>
+						<reference key="NSSuperview" ref="774585933"/>
+						<reference key="NSWindow"/>
+						<reference key="NSNextKeyView" ref="662730613"/>
+						<string key="NSReuseIdentifierKey">_NS:9</string>
+						<bool key="IBUIOpaque">NO</bool>
+						<string key="targetRuntimeIdentifier">IBCocoaTouchFramework</string>
+						<int key="IBUIContentHorizontalAlignment">0</int>
+						<int key="IBUIContentVerticalAlignment">0</int>
+						<object class="NSColor" key="IBUIHighlightedTitleColor">
+							<int key="NSColorSpace">3</int>
+							<bytes key="NSWhite">MQA</bytes>
+						</object>
+						<object class="NSColor" key="IBUINormalTitleColor">
+							<int key="NSColorSpace">1</int>
+							<bytes key="NSRGB">MC4xOTYwNzg0MzE0IDAuMzA5ODAzOTIxNiAwLjUyMTU2ODYyNzUAA</bytes>
+						</object>
+						<reference key="IBUINormalTitleShadowColor" ref="402492274"/>
+						<object class="IBUIFontDescription" key="IBUIFontDescription">
+							<int key="type">2</int>
+							<int key="size">2</int>
+						</object>
+						<object class="NSFont" key="IBUIFont">
+							<string key="NSName">Helvetica-Bold</string>
+							<double key="NSSize">18</double>
+							<int key="NSfFlags">16</int>
+						</object>
+					</object>
 				</array>
 				<string key="NSFrame">{{0, 20}, {320, 548}}</string>
 				<reference key="NSSuperview"/>
+				<reference key="NSWindow"/>
 				<reference key="NSNextKeyView" ref="512799957"/>
 				<object class="NSColor" key="IBUIBackgroundColor">
 					<int key="NSColorSpace">1</int>
@@ -203,6 +250,14 @@
 					<int key="connectionID">93</int>
 				</object>
 				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchOutletConnection" key="connection">
+						<string key="label">screenImageView</string>
+						<reference key="source" ref="372490531"/>
+						<reference key="destination" ref="662854777"/>
+					</object>
+					<int key="connectionID">344</int>
+				</object>
+				<object class="IBConnectionRecord">
 					<object class="IBCocoaTouchEventConnection" key="connection">
 						<string key="label">toggleConnected:</string>
 						<reference key="source" ref="345910302"/>
@@ -210,6 +265,15 @@
 						<int key="IBEventType">7</int>
 					</object>
 					<int key="connectionID">314</int>
+				</object>
+				<object class="IBConnectionRecord">
+					<object class="IBCocoaTouchEventConnection" key="connection">
+						<string key="label">saveScreenshot:</string>
+						<reference key="source" ref="875226812"/>
+						<reference key="destination" ref="372490531"/>
+						<int key="IBEventType">7</int>
+					</object>
+					<int key="connectionID">464</int>
 				</object>
 			</array>
 			<object class="IBMutableOrderedSet" key="objectRecords">
@@ -315,6 +379,102 @@
 								<float key="scoringTypeFloat">29</float>
 								<int key="contentType">3</int>
 							</object>
+							<object class="IBNSLayoutConstraint" id="434517735">
+								<reference key="firstItem" ref="875226812"/>
+								<int key="firstAttribute">4</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="662854777"/>
+								<int key="secondAttribute">4</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="774585933"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="20674245">
+								<reference key="firstItem" ref="875226812"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="662854777"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="774585933"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="737205389">
+								<reference key="firstItem" ref="875226812"/>
+								<int key="firstAttribute">5</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="662854777"/>
+								<int key="secondAttribute">5</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="774585933"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="351582117">
+								<reference key="firstItem" ref="875226812"/>
+								<int key="firstAttribute">6</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="662854777"/>
+								<int key="secondAttribute">6</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="774585933"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="559760860">
+								<reference key="firstItem" ref="875226812"/>
+								<int key="firstAttribute">9</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="988349355"/>
+								<int key="secondAttribute">9</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">0.0</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="774585933"/>
+								<int key="scoringType">6</int>
+								<float key="scoringTypeFloat">24</float>
+								<int key="contentType">2</int>
+							</object>
+							<object class="IBNSLayoutConstraint" id="683032837">
+								<reference key="firstItem" ref="662854777"/>
+								<int key="firstAttribute">3</int>
+								<int key="relation">0</int>
+								<reference key="secondItem" ref="774585933"/>
+								<int key="secondAttribute">3</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">145</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="774585933"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">3</int>
+							</object>
 							<object class="IBNSLayoutConstraint" id="32804612">
 								<reference key="firstItem" ref="988349355"/>
 								<int key="firstAttribute">5</int>
@@ -399,6 +559,8 @@
 							<reference ref="988349355"/>
 							<reference ref="662730613"/>
 							<reference ref="345910302"/>
+							<reference ref="662854777"/>
+							<reference ref="875226812"/>
 						</array>
 						<reference key="parent" ref="0"/>
 					</object>
@@ -572,16 +734,6 @@
 						<reference key="parent" ref="774585933"/>
 					</object>
 					<object class="IBObjectRecord">
-						<int key="objectID">251</int>
-						<reference key="object" ref="259351004"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
-						<int key="objectID">305</int>
-						<reference key="object" ref="32804612"/>
-						<reference key="parent" ref="774585933"/>
-					</object>
-					<object class="IBObjectRecord">
 						<int key="objectID">308</int>
 						<reference key="object" ref="8756466"/>
 						<reference key="parent" ref="774585933"/>
@@ -606,6 +758,102 @@
 						<reference key="object" ref="134585279"/>
 						<reference key="parent" ref="345910302"/>
 					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">315</int>
+						<reference key="object" ref="662854777"/>
+						<array class="NSMutableArray" key="children">
+							<object class="IBNSLayoutConstraint" id="956277552">
+								<reference key="firstItem" ref="662854777"/>
+								<int key="firstAttribute">7</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">114</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="662854777"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">345</int>
+						<reference key="object" ref="875226812"/>
+						<array class="NSMutableArray" key="children">
+							<object class="IBNSLayoutConstraint" id="1037290595">
+								<reference key="firstItem" ref="875226812"/>
+								<int key="firstAttribute">8</int>
+								<int key="relation">0</int>
+								<nil key="secondItem"/>
+								<int key="secondAttribute">0</int>
+								<float key="multiplier">1</float>
+								<object class="IBLayoutConstant" key="constant">
+									<double key="value">135</double>
+								</object>
+								<float key="priority">1000</float>
+								<reference key="containingView" ref="875226812"/>
+								<int key="scoringType">3</int>
+								<float key="scoringTypeFloat">9</float>
+								<int key="contentType">1</int>
+							</object>
+						</array>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">437</int>
+						<reference key="object" ref="559760860"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">441</int>
+						<reference key="object" ref="351582117"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">442</int>
+						<reference key="object" ref="32804612"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">443</int>
+						<reference key="object" ref="737205389"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">454</int>
+						<reference key="object" ref="259351004"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">460</int>
+						<reference key="object" ref="683032837"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">462</int>
+						<reference key="object" ref="20674245"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">463</int>
+						<reference key="object" ref="434517735"/>
+						<reference key="parent" ref="774585933"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">466</int>
+						<reference key="object" ref="956277552"/>
+						<reference key="parent" ref="662854777"/>
+					</object>
+					<object class="IBObjectRecord">
+						<int key="objectID">467</int>
+						<reference key="object" ref="1037290595"/>
+						<reference key="parent" ref="875226812"/>
+					</object>
 				</array>
 			</object>
 			<dictionary class="NSMutableDictionary" key="flattenedProperties">
@@ -625,19 +873,37 @@
 				<string key="240.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="241.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="247.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="251.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
-				<string key="305.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="308.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="309.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="311.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="312.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="313.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="315.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<array key="315.IBViewMetadataConstraints">
+					<reference ref="956277552"/>
+				</array>
+				<boolean value="NO" key="315.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="345.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<array class="NSMutableArray" key="345.IBViewMetadataConstraints">
+					<reference ref="1037290595"/>
+				</array>
+				<boolean value="NO" key="345.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
 				<string key="39.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="437.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="441.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="442.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="443.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="45.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<array class="NSMutableArray" key="45.IBViewMetadataConstraints">
 					<reference ref="103427869"/>
 				</array>
 				<boolean value="NO" key="45.IBViewMetadataTranslatesAutoresizingMaskIntoConstraints"/>
+				<string key="454.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="460.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="462.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="463.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="466.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
+				<string key="467.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="48.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<string key="6.IBPluginDependency">com.apple.InterfaceBuilder.IBCocoaTouchPlugin</string>
 				<reference key="6.IBUserGuides" ref="0"/>
@@ -647,6 +913,12 @@
 					<reference ref="259351004"/>
 					<reference ref="81726586"/>
 					<reference ref="32804612"/>
+					<reference ref="683032837"/>
+					<reference ref="559760860"/>
+					<reference ref="351582117"/>
+					<reference ref="737205389"/>
+					<reference ref="20674245"/>
+					<reference ref="434517735"/>
 					<reference ref="506064844"/>
 					<reference ref="231954431"/>
 					<reference ref="8756466"/>
@@ -671,9 +943,61 @@
 			<nil key="activeLocalization"/>
 			<dictionary class="NSMutableDictionary" key="localizations"/>
 			<nil key="sourceID"/>
-			<int key="maxID">314</int>
+			<int key="maxID">467</int>
 		</object>
-		<object class="IBClassDescriber" key="IBDocument.Classes"/>
+		<object class="IBClassDescriber" key="IBDocument.Classes">
+			<array class="NSMutableArray" key="referencedPartialClassDescriptions">
+				<object class="IBPartialClassDescription">
+					<string key="className">KBViewController</string>
+					<string key="superclassName">UIViewController</string>
+					<dictionary class="NSMutableDictionary" key="actions">
+						<string key="saveScreenshot:">id</string>
+						<string key="toggleConnected:">id</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="actionInfosByName">
+						<object class="IBActionInfo" key="saveScreenshot:">
+							<string key="name">saveScreenshot:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+						<object class="IBActionInfo" key="toggleConnected:">
+							<string key="name">toggleConnected:</string>
+							<string key="candidateClassName">id</string>
+						</object>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="outlets">
+						<string key="connectButton">UIButton</string>
+						<string key="connectedLabel">UILabel</string>
+						<string key="screenImageView">UIImageView</string>
+					</dictionary>
+					<dictionary class="NSMutableDictionary" key="toOneOutletInfosByName">
+						<object class="IBToOneOutletInfo" key="connectButton">
+							<string key="name">connectButton</string>
+							<string key="candidateClassName">UIButton</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="connectedLabel">
+							<string key="name">connectedLabel</string>
+							<string key="candidateClassName">UILabel</string>
+						</object>
+						<object class="IBToOneOutletInfo" key="screenImageView">
+							<string key="name">screenImageView</string>
+							<string key="candidateClassName">UIImageView</string>
+						</object>
+					</dictionary>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/KBViewController.h</string>
+					</object>
+				</object>
+				<object class="IBPartialClassDescription">
+					<string key="className">NSLayoutConstraint</string>
+					<string key="superclassName">NSObject</string>
+					<object class="IBClassDescriptionSource" key="sourceIdentifier">
+						<string key="majorKey">IBProjectSource</string>
+						<string key="minorKey">./Classes/NSLayoutConstraint.h</string>
+					</object>
+				</object>
+			</array>
+		</object>
 		<int key="IBDocument.localizationMode">0</int>
 		<string key="IBDocument.TargetRuntimeIdentifier">IBCocoaTouchFramework</string>
 		<bool key="IBDocument.PluginDeclaredDependenciesTrackSystemTargetVersion">YES</bool>


### PR DESCRIPTION
Hi,

After a fun little adventure coding for the Pebble I have now added a screenshot feature to httpebble. The screen capture part in "httpcapture.c" is a bit of a hack (the Pebble part). I wrote a little about this journey here http://memention.com/blog/2013/07/20/Yak-shaving-a-Pebble.html

This commit adds a receiving part to httpebble-ios. When a screenshot is sent to the iPhone it will be shown on the Pebble image and tapping it will make it possible to save the screenshot to the camera roll.

I used 0xFFF9 as the key for a framebuffer slice. The http.c version I use can be found in pblindex https://github.com/epatel/pblindex and the extra parts in "http.c" is in "httpcapture.c" with minimal changes in http.c. 

Hope you like it :) Would love to see it in an official App Store version (so I don't need to be compiling it myself and its easier for others to use it)
